### PR TITLE
Remove the name of return values without some cases

### DIFF
--- a/auth/crypto.go
+++ b/auth/crypto.go
@@ -8,9 +8,9 @@ type Key interface {
 
 type Crypto interface {
 
-	Sign(digest []byte, opts SignerOpts) (signature []byte, err error)
+	Sign(digest []byte, opts SignerOpts) ([]byte, error)
 
-	Verify(key Key, signature, digest []byte, opts SignerOpts) (valid bool, err error)
+	Verify(key Key, signature, digest []byte, opts SignerOpts) (bool, error)
 
 	GenerateKey(opts KeyGenOpts) (pri, pub Key, err error)
 

--- a/auth/cryptoImpl.go
+++ b/auth/cryptoImpl.go
@@ -46,7 +46,9 @@ func NewCrypto(path string) (Crypto, error) {
 
 }
 
-func (ch *cryptoHelper) Sign(digest []byte, opts SignerOpts) (signature []byte, err error) {
+func (ch *cryptoHelper) Sign(digest []byte, opts SignerOpts) ([]byte, error) {
+
+	var err error
 
 	ch.priKey, ch.pubKey, err = ch.LoadKey()
 	if err != nil {
@@ -66,16 +68,16 @@ func (ch *cryptoHelper) Sign(digest []byte, opts SignerOpts) (signature []byte, 
 		return nil, errors.New("unsupported key type.")
 	}
 
-	signature, err = signer.Sign(ch.priKey, digest, opts)
+	signature, err := signer.Sign(ch.priKey, digest, opts)
 	if err != nil {
 		return nil, errors.New("signing error is occurred")
 	}
 
-	return
+	return signature, err
 
 }
 
-func (ch *cryptoHelper) Verify(key Key, signature, digest []byte, opts SignerOpts) (valid bool, err error) {
+func (ch *cryptoHelper) Verify(key Key, signature, digest []byte, opts SignerOpts) (bool, error) {
 
 	if key == nil {
 		return false, errors.New("invalid key")
@@ -94,12 +96,12 @@ func (ch *cryptoHelper) Verify(key Key, signature, digest []byte, opts SignerOpt
 		return false, errors.New("unsupported key type")
 	}
 
-	valid, err = verifier.Verify(key, signature, digest, opts)
+	valid, err := verifier.Verify(key, signature, digest, opts)
 	if err != nil {
 		return false, errors.New("verifying error is occurred")
 	}
 
-	return
+	return valid, nil
 
 }
 
@@ -124,17 +126,17 @@ func (ch *cryptoHelper) GenerateKey(opts KeyGenOpts) (pri, pub Key, err error) {
 		return nil, nil, errors.New("Failed to store a Key")
 	}
 
-	return
+	return pri, pub, nil
 
 }
 
-func (ch *cryptoHelper) LoadKey() (pri Key, pub Key, err error) {
+func (ch *cryptoHelper) LoadKey() (pri, pub Key, err error) {
 
 	pri, pub, err = ch.keyManager.Load()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return
+	return pri, pub, err
 
 }

--- a/auth/ecdsa.go
+++ b/auth/ecdsa.go
@@ -16,7 +16,7 @@ type ecdsaSignature struct {
 
 type ecdsaSigner struct{}
 
-func marshalECDSASignature(r, s *big.Int) (signature []byte, err error) {
+func marshalECDSASignature(r, s *big.Int) ([]byte, error) {
 	return asn1.Marshal(ecdsaSignature{r, s})
 }
 
@@ -80,7 +80,7 @@ type ecdsaPrivateKey struct {
 	priv *ecdsa.PrivateKey
 }
 
-func (key *ecdsaPrivateKey) SKI() (ski []byte) {
+func (key *ecdsaPrivateKey) SKI() ([]byte) {
 
 	if key.priv == nil {
 		return nil
@@ -94,7 +94,7 @@ func (key *ecdsaPrivateKey) SKI() (ski []byte) {
 
 }
 
-func (key *ecdsaPrivateKey) PublicKey() (pub Key, err error) {
+func (key *ecdsaPrivateKey) PublicKey() (Key, error) {
 	return &ecdsaPublicKey{&key.priv.PublicKey}, nil
 }
 
@@ -102,7 +102,7 @@ type ecdsaPublicKey struct {
 	pub *ecdsa.PublicKey
 }
 
-func (key *ecdsaPublicKey) SKI() (ski []byte) {
+func (key *ecdsaPublicKey) SKI() ([]byte) {
 
 	if key.pub == nil {
 		return nil

--- a/auth/internals.go
+++ b/auth/internals.go
@@ -8,13 +8,13 @@ type SignerOpts interface {
 
 type signer interface {
 
-	Sign(key Key, digest []byte, opts SignerOpts) (signature []byte, err error)
+	Sign(key Key, digest []byte, opts SignerOpts) ([]byte, error)
 
 }
 
 type verifier interface {
 
-	Verify(key Key, signature, digest []byte, opts SignerOpts) (valid bool, err error)
+	Verify(key Key, signature, digest []byte, opts SignerOpts) (bool, error)
 
 }
 

--- a/auth/keyManager.go
+++ b/auth/keyManager.go
@@ -60,9 +60,10 @@ func (km *keyManager) Store(keys... Key) (err error) {
 	return nil
 }
 
-func (km *keyManager) storeKey(key Key, keyType keyType) (err error) {
+func (km *keyManager) storeKey(key Key, keyType keyType) (error) {
 
 	var data []byte
+	var err error
 
 	switch keyType {
 	case PRIVATE_KEY:
@@ -74,12 +75,12 @@ func (km *keyManager) storeKey(key Key, keyType keyType) (err error) {
 	}
 
 	if err != nil {
-		return
+		return err
 	}
 
 	path, err := km.getFullPath(hex.EncodeToString(key.SKI()), string(keyType))
 	if err != nil {
-		return
+		return err
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -147,7 +148,7 @@ func (km *keyManager) Load() (pri, pub Key, err error) {
 		return nil, nil, errors.New("Failed to load Key")
 	}
 
-	return
+	return pri, pub, nil
 
 }
 
@@ -178,11 +179,11 @@ func (km *keyManager) loadKey(alias string, keyType keyType) (key interface{}, e
 		return nil, err
 	}
 
-	return
+	return key, nil
 
 }
 
-func (km *keyManager) getSuffix(name string) (suffix string, valid bool) {
+func (km *keyManager) getSuffix(name string) (string, bool) {
 
 	if strings.HasSuffix(name, "pri") {
 		return "pri", true
@@ -194,7 +195,7 @@ func (km *keyManager) getSuffix(name string) (suffix string, valid bool) {
 
 }
 
-func (km *keyManager) getFullPath(alias, suffix string) (path string, err error) {
+func (km *keyManager) getFullPath(alias, suffix string) (string, error) {
 	if _, err := os.Stat(km.path); os.IsNotExist(err) {
 		err = os.MkdirAll(km.path, 0755)
 		if err != nil {

--- a/auth/keyUtils.go
+++ b/auth/keyUtils.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 )
 
-func PublicKeyToPEM(pub Key) (data []byte, err error) {
+func PublicKeyToPEM(pub Key) ([]byte, error) {
 
 	if pub == nil {
 		return nil, errors.New("Invalid Key")
@@ -47,7 +47,7 @@ func PublicKeyToPEM(pub Key) (data []byte, err error) {
 
 }
 
-func PrivateKeyToPEM(pri Key) (data []byte, err error) {
+func PrivateKeyToPEM(pri Key) ([]byte, error) {
 
 	if pri == nil {
 		return nil, errors.New("Invalid Private Key")
@@ -82,7 +82,8 @@ func PrivateKeyToPEM(pri Key) (data []byte, err error) {
 	}
 }
 
-func PEMToPublicKey(data []byte) (key interface{}, err error) {
+func PEMToPublicKey(data []byte) (interface{}, error) {
+
 	if len(data) == 0 {
 		return nil, errors.New("Input data should not be NIL")
 	}
@@ -92,15 +93,16 @@ func PEMToPublicKey(data []byte) (key interface{}, err error) {
 		return nil, errors.New("Failed to decode data")
 	}
 
-	key, err = DERToPublicKey(block.Bytes)
+	key, err := DERToPublicKey(block.Bytes)
 	if err != nil {
 		return nil, errors.New("Failed to convert PEM data to public key")
 	}
 
-	return
+	return key, nil
+
 }
 
-func PEMToPrivateKey(data []byte) (key interface{}, err error) {
+func PEMToPrivateKey(data []byte) (interface{}, error) {
 	if len(data) == 0 {
 		return nil, errors.New("Input data should not be NIL")
 	}
@@ -110,34 +112,40 @@ func PEMToPrivateKey(data []byte) (key interface{}, err error) {
 		return nil, errors.New("Failed to decode data")
 	}
 
-	key, err = DERToPrivateKey(block.Bytes)
+	key, err := DERToPrivateKey(block.Bytes)
 	if err != nil {
 		return nil, errors.New("Failed to convert PEM data to private key")
 	}
 
-	return
+	return key, nil
 
 }
 
-func DERToPublicKey(data []byte) (key interface{}, err error) {
+func DERToPublicKey(data []byte) (interface{}, error) {
+
 	if len(data) == 0 {
 		return nil, errors.New("Input data should not be NIL")
 	}
 
-	key, err = x509.ParsePKIXPublicKey(data)
+	key, err := x509.ParsePKIXPublicKey(data)
 	if err != nil {
 		return nil, errors.New("Failed to Parse data")
 	}
 
-	return
+	return key, nil
+
 }
 
-func DERToPrivateKey(data []byte) (key interface{}, err error) {
+func DERToPrivateKey(data []byte) (interface{}, error) {
+
+	var key interface{}
+	var err error
+
 	if len(data) == 0 {
 		return nil, errors.New("Input data should not be NIL")
 	}
 
-	if key, err = x509.ParsePKCS1PrivateKey(data); err == nil {
+	if key, err := x509.ParsePKCS1PrivateKey(data); err == nil {
 		return key, err
 	}
 
@@ -146,6 +154,7 @@ func DERToPrivateKey(data []byte) (key interface{}, err error) {
 	}
 
 	return nil, errors.New("Unspported Private Key Type")
+
 }
 
 

--- a/auth/keygen.go
+++ b/auth/keygen.go
@@ -31,7 +31,7 @@ func (keygen *rsaKeyGenerator) GenerateKey(opts KeyGenOpts) (pri, pub Key, err e
 		return nil, nil, err
 	}
 
-	return
+	return pri, pub, nil
 
 }
 
@@ -57,6 +57,6 @@ func (keygen *ecdsaKeyGenerator) GenerateKey(opts KeyGenOpts) (pri, pub Key, err
 		return nil, nil, err
 	}
 
-	return
+	return pri, pub, nil
 
 }

--- a/auth/rsa.go
+++ b/auth/rsa.go
@@ -11,7 +11,7 @@ import (
 
 type rsaSigner struct{}
 
-func (s *rsaSigner) Sign(key Key, digest []byte, opts SignerOpts) (signature []byte, err error) {
+func (s *rsaSigner) Sign(key Key, digest []byte, opts SignerOpts) ([]byte, error) {
 
 	if opts == nil {
 		return nil, errors.New("invalid options")
@@ -23,7 +23,7 @@ func (s *rsaSigner) Sign(key Key, digest []byte, opts SignerOpts) (signature []b
 
 type rsaVerifier struct{}
 
-func (v *rsaVerifier) Verify(key Key, signature, digest []byte, opts SignerOpts) (valid bool, err error) {
+func (v *rsaVerifier) Verify(key Key, signature, digest []byte, opts SignerOpts) (bool, error) {
 
 	if opts == nil {
 		return false, errors.New("invalid options")
@@ -55,7 +55,7 @@ type rsaPrivateKey struct {
 	priv *rsa.PrivateKey
 }
 
-func (key *rsaPrivateKey) SKI() (ski []byte) {
+func (key *rsaPrivateKey) SKI() ([]byte) {
 
 	if key.priv == nil {
 		return nil
@@ -79,7 +79,7 @@ type rsaPublicKey struct {
 	pub *rsa.PublicKey
 }
 
-func (key *rsaPublicKey) SKI() (ski []byte) {
+func (key *rsaPublicKey) SKI() ([]byte) {
 
 	if key.pub == nil {
 		return nil


### PR DESCRIPTION
- Remove the name of return values without some cases
- Add variables name at the end of functions instead of removing the name of return values